### PR TITLE
feat(obsidian): add ObsidianApp context tag and ObsidianAdapter service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,6 @@
 export * from "./errors.js";
 export * from "./schemas.js";
 export * from "./services/KavitaClient.js";
+export * from "./services/ObsidianAdapter.js";
+export * from "./services/ObsidianApp.js";
 export * from "./services/PluginConfig.js";

--- a/src/services/ObsidianAdapter.test.ts
+++ b/src/services/ObsidianAdapter.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for ObsidianAdapter service.
+ *
+ * @module
+ */
+import { describe, it } from "@effect/vitest";
+import { Effect, Layer, Option } from "effect";
+import { expect } from "vitest";
+import { ObsidianFileNotFoundError, ObsidianWriteError } from "../errors.js";
+import { ObsidianAdapter } from "./ObsidianAdapter.js";
+import { ObsidianApp } from "./ObsidianApp.js";
+
+interface MockFile {
+	path: string;
+	extension: string;
+}
+
+interface MockVault {
+	getAbstractFileByPath: (path: string) => MockFile | null;
+	create: (path: string, content: string) => Promise<MockFile>;
+	modify: (file: { path: string }, content: string) => Promise<void>;
+	append: (file: { path: string }, content: string) => Promise<void>;
+	read: (file: { path: string }) => Promise<string>;
+	getMarkdownFiles: () => MockFile[];
+}
+
+interface MockApp {
+	vault: MockVault;
+	_files: Map<string, { path: string; content: string }>;
+}
+
+/**
+ * Creates a mock Obsidian App with an in-memory file system.
+ */
+const createMockApp = (initialFiles: Record<string, string> = {}): MockApp => {
+	const files = new Map<string, { path: string; content: string }>();
+
+	for (const [path, content] of Object.entries(initialFiles)) {
+		files.set(path, { path, content });
+	}
+
+	const mockVault: MockVault = {
+		getAbstractFileByPath: (path: string) => {
+			const file = files.get(path);
+			if (file) {
+				return { path: file.path, extension: "md" };
+			}
+			return null;
+		},
+		create: async (path: string, content: string) => {
+			files.set(path, { path, content });
+			return { path, extension: "md" };
+		},
+		modify: async (file: { path: string }, content: string) => {
+			files.set(file.path, { path: file.path, content });
+		},
+		append: async (file: { path: string }, content: string) => {
+			const existing = files.get(file.path);
+			if (existing) {
+				files.set(file.path, {
+					path: file.path,
+					content: existing.content + content,
+				});
+			}
+		},
+		read: async (file: { path: string }) => {
+			const existing = files.get(file.path);
+			return existing?.content ?? "";
+		},
+		getMarkdownFiles: () => {
+			return Array.from(files.values()).map((f) => ({
+				path: f.path,
+				extension: "md",
+			}));
+		},
+	};
+
+	return {
+		vault: mockVault,
+		_files: files,
+	};
+};
+
+const createMockAppLayer = (initialFiles: Record<string, string> = {}) => {
+	const mockApp = createMockApp(initialFiles);
+	return {
+		layer: Layer.succeed(ObsidianApp, mockApp as never),
+		mockApp,
+	};
+};
+
+describe("ObsidianAdapter", () => {
+	describe("writeFile", () => {
+		it.effect("creates a new file", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+				yield* adapter.writeFile("test.md", "Hello World");
+
+				const content = yield* adapter.readFile("test.md");
+				expect(content).toBe("Hello World");
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(createMockAppLayer().layer),
+			),
+		);
+
+		it.effect("overwrites existing file", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+				yield* adapter.writeFile("test.md", "Original");
+				yield* adapter.writeFile("test.md", "Updated");
+
+				const content = yield* adapter.readFile("test.md");
+				expect(content).toBe("Updated");
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(createMockAppLayer().layer),
+			),
+		);
+	});
+
+	describe("appendToFile", () => {
+		it.effect("appends to existing file", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+				yield* adapter.writeFile("test.md", "Line 1\n");
+				yield* adapter.appendToFile("test.md", "Line 2\n");
+
+				const content = yield* adapter.readFile("test.md");
+				expect(content).toBe("Line 1\nLine 2\n");
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(createMockAppLayer().layer),
+			),
+		);
+
+		it.effect("fails when file does not exist", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+				const result = yield* adapter
+					.appendToFile("nonexistent.md", "content")
+					.pipe(Effect.either);
+
+				expect(result._tag).toBe("Left");
+				if (result._tag === "Left") {
+					expect(result.left).toBeInstanceOf(ObsidianWriteError);
+				}
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(createMockAppLayer().layer),
+			),
+		);
+	});
+
+	describe("readFile", () => {
+		it.effect("reads existing file", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+
+				const content = yield* adapter.readFile("existing.md");
+				expect(content).toBe("Existing content");
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(
+					createMockAppLayer({ "existing.md": "Existing content" }).layer,
+				),
+			),
+		);
+
+		it.effect("fails when file does not exist", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+				const result = yield* adapter
+					.readFile("nonexistent.md")
+					.pipe(Effect.either);
+
+				expect(result._tag).toBe("Left");
+				if (result._tag === "Left") {
+					expect(result.left).toBeInstanceOf(ObsidianFileNotFoundError);
+				}
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(createMockAppLayer().layer),
+			),
+		);
+	});
+
+	describe("getFile", () => {
+		it.effect("returns Some for existing file", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+
+				const file = yield* adapter.getFile("existing.md");
+				expect(Option.isSome(file)).toBe(true);
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(createMockAppLayer({ "existing.md": "content" }).layer),
+			),
+		);
+
+		it.effect("returns None for nonexistent file", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+
+				const file = yield* adapter.getFile("nonexistent.md");
+				expect(Option.isNone(file)).toBe(true);
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(createMockAppLayer().layer),
+			),
+		);
+	});
+
+	describe("listMarkdownFiles", () => {
+		it.effect("lists all markdown files", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+
+				const files = yield* adapter.listMarkdownFiles;
+				expect(files).toHaveLength(2);
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(
+					createMockAppLayer({
+						"file1.md": "content1",
+						"file2.md": "content2",
+					}).layer,
+				),
+			),
+		);
+
+		it.effect("returns empty array when no files", () =>
+			Effect.gen(function* () {
+				const adapter = yield* ObsidianAdapter;
+
+				const files = yield* adapter.listMarkdownFiles;
+				expect(files).toHaveLength(0);
+			}).pipe(
+				Effect.provide(ObsidianAdapter.Default),
+				Effect.provide(createMockAppLayer().layer),
+			),
+		);
+	});
+});

--- a/src/services/ObsidianAdapter.ts
+++ b/src/services/ObsidianAdapter.ts
@@ -1,0 +1,109 @@
+/**
+ * Obsidian vault adapter service for file operations.
+ *
+ * @module
+ */
+import { Effect, Option } from "effect";
+import type { TFile } from "obsidian";
+import { ObsidianFileNotFoundError, ObsidianWriteError } from "../errors.js";
+import { ObsidianApp } from "./ObsidianApp.js";
+
+/**
+ * Obsidian adapter service.
+ *
+ * Provides methods for reading and writing files in the Obsidian vault.
+ *
+ * @since 0.0.1
+ * @category Services
+ */
+export class ObsidianAdapter extends Effect.Service<ObsidianAdapter>()(
+	"ObsidianAdapter",
+	{
+		effect: Effect.gen(function* () {
+			const app = yield* ObsidianApp;
+			const vault = app.vault;
+
+			/**
+			 * Write content to a file, creating it if it doesn't exist.
+			 *
+			 * @since 0.0.1
+			 */
+			const writeFile = (path: string, content: string) =>
+				Effect.tryPromise({
+					try: async () => {
+						const existingFile = vault.getAbstractFileByPath(path);
+						if (existingFile && "extension" in existingFile) {
+							await vault.modify(existingFile as TFile, content);
+						} else {
+							await vault.create(path, content);
+						}
+					},
+					catch: (e) => new ObsidianWriteError({ path, cause: e }),
+				});
+
+			/**
+			 * Append content to an existing file.
+			 *
+			 * @since 0.0.1
+			 */
+			const appendToFile = (path: string, content: string) =>
+				Effect.tryPromise({
+					try: async () => {
+						const file = vault.getAbstractFileByPath(path);
+						if (file && "extension" in file) {
+							await vault.append(file as TFile, content);
+						} else {
+							return Promise.reject(new Error("File does not exist"));
+						}
+					},
+					catch: (e) => new ObsidianWriteError({ path, cause: e }),
+				});
+
+			/**
+			 * Read content from a file.
+			 *
+			 * @since 0.0.1
+			 */
+			const readFile = (path: string) =>
+				Effect.tryPromise({
+					try: async () => {
+						const file = vault.getAbstractFileByPath(path);
+						if (file && "extension" in file) {
+							return vault.read(file as TFile);
+						}
+						return Promise.reject(new Error("File not found"));
+					},
+					catch: () => new ObsidianFileNotFoundError({ path }),
+				});
+
+			/**
+			 * Get a file by path, returning None if not found.
+			 *
+			 * @since 0.0.1
+			 */
+			const getFile = (path: string): Effect.Effect<Option.Option<TFile>> =>
+				Effect.sync(() => {
+					const file = vault.getAbstractFileByPath(path);
+					if (file && "extension" in file) {
+						return Option.some(file as TFile);
+					}
+					return Option.none();
+				});
+
+			/**
+			 * List all markdown files in the vault.
+			 *
+			 * @since 0.0.1
+			 */
+			const listMarkdownFiles = Effect.sync(() => vault.getMarkdownFiles());
+
+			return {
+				writeFile,
+				appendToFile,
+				readFile,
+				getFile,
+				listMarkdownFiles,
+			};
+		}),
+	},
+) {}

--- a/src/services/ObsidianApp.ts
+++ b/src/services/ObsidianApp.ts
@@ -1,0 +1,20 @@
+/**
+ * Obsidian App context tag for dependency injection.
+ *
+ * @module
+ */
+import { Context } from "effect";
+import type { App } from "obsidian";
+
+/**
+ * Context tag for the Obsidian App instance.
+ *
+ * This is provided by the plugin at runtime and gives access to the vault.
+ *
+ * @since 0.0.1
+ * @category Context
+ */
+export class ObsidianApp extends Context.Tag("ObsidianApp")<
+	ObsidianApp,
+	App
+>() {}


### PR DESCRIPTION
## Summary

- Adds `ObsidianApp` context tag for dependency injection of Obsidian App instance
- Adds `ObsidianAdapter` service with file operations: `writeFile`, `appendToFile`, `readFile`, `getFile`, `listMarkdownFiles`
- Full test coverage with mock vault implementation

## Test plan

- [x] All 18 tests passing
- [x] TypeScript compiles without errors
- [x] Biome lint passes