### PR TITLE
feat: add AnnotationFormatter and AnnotationSyncer

### DIFF
--- a/src/formatters/markdown.test.ts
+++ b/src/formatters/markdown.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for markdown formatter functions.
+ *
+ * @module
+ */
+import { Option } from "effect";
+import { describe, expect, it } from "vitest";
+import type { AnnotationDto } from "../schemas.js";
+import {
+	formatAnnotation,
+	groupByChapterId,
+	groupBySeriesId,
+	toMarkdown,
+} from "./markdown.js";
+
+const createAnnotation = (
+	overrides: Partial<typeof AnnotationDto.Type> = {},
+): typeof AnnotationDto.Type => ({
+	id: 1,
+	chapterId: 1,
+	content: "Test highlight",
+	spoiler: false,
+	highlightSlot: 0,
+	...overrides,
+});
+
+describe("formatAnnotation", () => {
+	it("formats basic annotation", () => {
+		const annotation = createAnnotation({ content: "Hello world" });
+		const result = formatAnnotation(annotation, {
+			includeComments: true,
+			includeSpoilers: false,
+		});
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toBe("> Hello world");
+		}
+	});
+
+	it("includes comment when enabled", () => {
+		const annotation = createAnnotation({
+			content: "Highlight",
+			comment: "My note",
+		});
+		const result = formatAnnotation(annotation, {
+			includeComments: true,
+			includeSpoilers: false,
+		});
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toContain("*Note:* My note");
+		}
+	});
+
+	it("excludes comment when disabled", () => {
+		const annotation = createAnnotation({
+			content: "Highlight",
+			comment: "My note",
+		});
+		const result = formatAnnotation(annotation, {
+			includeComments: false,
+			includeSpoilers: false,
+		});
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).not.toContain("My note");
+		}
+	});
+
+	it("includes page number when present", () => {
+		const annotation = createAnnotation({ content: "Highlight", page: 42 });
+		const result = formatAnnotation(annotation, {
+			includeComments: true,
+			includeSpoilers: false,
+		});
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toContain("<small>Page 42</small>");
+		}
+	});
+
+	it("filters spoilers when disabled", () => {
+		const annotation = createAnnotation({ content: "Spoiler", spoiler: true });
+		const result = formatAnnotation(annotation, {
+			includeComments: true,
+			includeSpoilers: false,
+		});
+
+		expect(Option.isNone(result)).toBe(true);
+	});
+
+	it("includes spoilers when enabled", () => {
+		const annotation = createAnnotation({ content: "Spoiler", spoiler: true });
+		const result = formatAnnotation(annotation, {
+			includeComments: true,
+			includeSpoilers: true,
+		});
+
+		expect(Option.isSome(result)).toBe(true);
+	});
+});
+
+describe("groupBySeriesId", () => {
+	it("groups annotations by series", () => {
+		const annotations = [
+			createAnnotation({ id: 1, seriesId: 1 }),
+			createAnnotation({ id: 2, seriesId: 1 }),
+			createAnnotation({ id: 3, seriesId: 2 }),
+		];
+
+		const groups = groupBySeriesId(annotations);
+
+		expect(groups.size).toBe(2);
+		expect(groups.get(1)?.length).toBe(2);
+		expect(groups.get(2)?.length).toBe(1);
+	});
+
+	it("handles undefined seriesId", () => {
+		const annotations = [
+			createAnnotation({ id: 1, seriesId: undefined }),
+			createAnnotation({ id: 2, seriesId: 1 }),
+		];
+
+		const groups = groupBySeriesId(annotations);
+
+		expect(groups.size).toBe(2);
+		expect(groups.get(undefined)?.length).toBe(1);
+		expect(groups.get(1)?.length).toBe(1);
+	});
+});
+
+describe("groupByChapterId", () => {
+	it("groups annotations by chapter", () => {
+		const annotations = [
+			createAnnotation({ id: 1, chapterId: 1 }),
+			createAnnotation({ id: 2, chapterId: 1 }),
+			createAnnotation({ id: 3, chapterId: 2 }),
+		];
+
+		const groups = groupByChapterId(annotations);
+
+		expect(groups.size).toBe(2);
+		expect(groups.get(1)?.length).toBe(2);
+		expect(groups.get(2)?.length).toBe(1);
+	});
+});
+
+describe("toMarkdown", () => {
+	it("returns empty message for no annotations", () => {
+		const result = toMarkdown([], {
+			includeComments: true,
+			includeSpoilers: false,
+		});
+
+		expect(result).toContain("# Kavita Annotations");
+		expect(result).toContain("*No annotations found.*");
+	});
+
+	it("generates markdown with series and chapter grouping", () => {
+		const annotations = [
+			createAnnotation({ id: 1, seriesId: 1, chapterId: 1, content: "First" }),
+			createAnnotation({ id: 2, seriesId: 1, chapterId: 2, content: "Second" }),
+			createAnnotation({ id: 3, seriesId: 2, chapterId: 1, content: "Third" }),
+		];
+
+		const result = toMarkdown(annotations, {
+			includeComments: true,
+			includeSpoilers: false,
+		});
+
+		expect(result).toContain("# Kavita Annotations");
+		expect(result).toContain("## Series 1");
+		expect(result).toContain("## Series 2");
+		expect(result).toContain("### Chapter 1");
+		expect(result).toContain("### Chapter 2");
+		expect(result).toContain("> First");
+		expect(result).toContain("> Second");
+		expect(result).toContain("> Third");
+	});
+
+	it("filters spoilers based on options", () => {
+		const annotations = [
+			createAnnotation({ id: 1, content: "Normal", spoiler: false }),
+			createAnnotation({ id: 2, content: "Secret", spoiler: true }),
+		];
+
+		const result = toMarkdown(annotations, {
+			includeComments: true,
+			includeSpoilers: false,
+		});
+
+		expect(result).toContain("> Normal");
+		expect(result).not.toContain("> Secret");
+	});
+});

--- a/src/formatters/markdown.ts
+++ b/src/formatters/markdown.ts
@@ -1,0 +1,134 @@
+/**
+ * Pure formatting functions for converting annotations to markdown.
+ *
+ * @module
+ */
+import { Option } from "effect";
+import type { AnnotationDto } from "../schemas.js";
+
+/**
+ * Options for formatting annotations.
+ *
+ * @since 0.0.1
+ * @category Formatters
+ */
+export interface FormatOptions {
+	readonly includeComments: boolean;
+	readonly includeSpoilers: boolean;
+}
+
+/**
+ * Format a single annotation to markdown.
+ *
+ * @since 0.0.1
+ * @category Formatters
+ */
+export const formatAnnotation = (
+	annotation: typeof AnnotationDto.Type,
+	options: FormatOptions,
+): Option.Option<string> => {
+	if (annotation.spoiler && !options.includeSpoilers) {
+		return Option.none();
+	}
+
+	const lines: string[] = [];
+
+	lines.push(`> ${annotation.content}`);
+
+	if (options.includeComments && annotation.comment) {
+		lines.push("");
+		lines.push(`*Note:* ${annotation.comment}`);
+	}
+
+	if (annotation.page !== undefined) {
+		lines.push("");
+		lines.push(`<small>Page ${annotation.page}</small>`);
+	}
+
+	return Option.some(lines.join("\n"));
+};
+
+/**
+ * Group annotations by seriesId.
+ *
+ * @since 0.0.1
+ * @category Formatters
+ */
+export const groupBySeriesId = (
+	annotations: ReadonlyArray<typeof AnnotationDto.Type>,
+): Map<number | undefined, Array<typeof AnnotationDto.Type>> => {
+	const groups = new Map<
+		number | undefined,
+		Array<typeof AnnotationDto.Type>
+	>();
+
+	for (const annotation of annotations) {
+		const key = annotation.seriesId;
+		const existing = groups.get(key) ?? [];
+		existing.push(annotation);
+		groups.set(key, existing);
+	}
+
+	return groups;
+};
+
+/**
+ * Group annotations by chapterId.
+ *
+ * @since 0.0.1
+ * @category Formatters
+ */
+export const groupByChapterId = (
+	annotations: ReadonlyArray<typeof AnnotationDto.Type>,
+): Map<number, Array<typeof AnnotationDto.Type>> => {
+	const groups = new Map<number, Array<typeof AnnotationDto.Type>>();
+
+	for (const annotation of annotations) {
+		const key = annotation.chapterId;
+		const existing = groups.get(key) ?? [];
+		existing.push(annotation);
+		groups.set(key, existing);
+	}
+
+	return groups;
+};
+
+/**
+ * Convert annotations to a markdown document.
+ *
+ * @since 0.0.1
+ * @category Formatters
+ */
+export const toMarkdown = (
+	annotations: ReadonlyArray<typeof AnnotationDto.Type>,
+	options: FormatOptions,
+): string => {
+	if (annotations.length === 0) {
+		return "# Kavita Annotations\n\n*No annotations found.*\n";
+	}
+
+	const lines: string[] = ["# Kavita Annotations", ""];
+
+	const seriesGroups = groupBySeriesId(annotations);
+
+	for (const [seriesId, seriesAnnotations] of seriesGroups) {
+		const seriesTitle =
+			seriesId !== undefined ? `Series ${seriesId}` : "Ungrouped";
+		lines.push(`## ${seriesTitle}`, "");
+
+		const chapterGroups = groupByChapterId(seriesAnnotations);
+
+		for (const [chapterId, chapterAnnotations] of chapterGroups) {
+			lines.push(`### Chapter ${chapterId}`, "");
+
+			for (const annotation of chapterAnnotations) {
+				const formatted = formatAnnotation(annotation, options);
+				if (Option.isSome(formatted)) {
+					lines.push(formatted.value, "", "---", "");
+				}
+			}
+		}
+	}
+
+	return lines.join("\n");
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,9 @@
  * @module
  */
 export * from "./errors.js";
+export * from "./formatters/markdown.js";
 export * from "./schemas.js";
+export * from "./services/AnnotationSyncer.js";
 export * from "./services/KavitaClient.js";
 export * from "./services/ObsidianAdapter.js";
 export * from "./services/ObsidianApp.js";

--- a/src/services/AnnotationSyncer.test.ts
+++ b/src/services/AnnotationSyncer.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for AnnotationSyncer service.
+ *
+ * @module
+ */
+import { describe, it } from "@effect/vitest";
+import { Effect, Layer, Option, Redacted } from "effect";
+import { expect } from "vitest";
+import type { AnnotationDto } from "../schemas.js";
+import { AnnotationSyncer } from "./AnnotationSyncer.js";
+import { KavitaClient } from "./KavitaClient.js";
+import { ObsidianAdapter } from "./ObsidianAdapter.js";
+import { PluginConfig } from "./PluginConfig.js";
+
+const createAnnotation = (
+	overrides: Partial<typeof AnnotationDto.Type> = {},
+): typeof AnnotationDto.Type => ({
+	id: 1,
+	chapterId: 1,
+	content: "Test highlight",
+	spoiler: false,
+	highlightSlot: 0,
+	...overrides,
+});
+
+const createMockKavitaClient = (
+	annotations: Array<typeof AnnotationDto.Type>,
+) =>
+	Layer.succeed(KavitaClient, {
+		fetchAllAnnotations: Effect.succeed(annotations),
+		fetchAnnotationsFiltered: () => Effect.succeed(annotations),
+	} as unknown as typeof KavitaClient.Service);
+
+const createMockObsidianAdapter = () => {
+	const files = new Map<string, string>();
+
+	const adapter = {
+		writeFile: (path: string, content: string) =>
+			Effect.sync(() => {
+				files.set(path, content);
+			}),
+		appendToFile: (path: string, content: string) =>
+			Effect.sync(() => {
+				const existing = files.get(path) ?? "";
+				files.set(path, existing + content);
+			}),
+		readFile: (path: string) =>
+			Effect.sync(() => {
+				return files.get(path) ?? "";
+			}),
+		getFile: (_path: string) => Effect.succeed(Option.none()),
+		listMarkdownFiles: Effect.succeed([]),
+	};
+
+	return {
+		layer: Layer.succeed(
+			ObsidianAdapter,
+			adapter as unknown as typeof ObsidianAdapter.Service,
+		),
+		files,
+	};
+};
+
+const createMockConfig = (
+	overrides: Partial<typeof PluginConfig.Service> = {},
+) =>
+	Layer.succeed(PluginConfig, {
+		kavitaUrl: new URL("http://localhost:5000"),
+		kavitaApiKey: Redacted.make("test-api-key"),
+		outputPath: "kavita-annotations.md",
+		matchThreshold: 0.7,
+		includeComments: true,
+		includeSpoilers: false,
+		...overrides,
+	} as unknown as typeof PluginConfig.Service);
+
+describe("AnnotationSyncer", () => {
+	describe("syncToFile", () => {
+		it.effect("syncs annotations to file", () => {
+			const mockObsidian = createMockObsidianAdapter();
+
+			return Effect.gen(function* () {
+				const syncer = yield* AnnotationSyncer;
+				const result = yield* syncer.syncToFile;
+
+				expect(result.count).toBe(2);
+				expect(result.outputPath).toBe("kavita-annotations.md");
+
+				const fileContent = mockObsidian.files.get("kavita-annotations.md");
+				expect(fileContent).toBeDefined();
+				expect(fileContent).toContain("First highlight");
+				expect(fileContent).toContain("Second highlight");
+			}).pipe(
+				Effect.provide(AnnotationSyncer.Default),
+				Effect.provide(
+					createMockKavitaClient([
+						createAnnotation({
+							id: 1,
+							seriesId: 1,
+							content: "First highlight",
+						}),
+						createAnnotation({
+							id: 2,
+							seriesId: 1,
+							content: "Second highlight",
+						}),
+					]),
+				),
+				Effect.provide(mockObsidian.layer),
+				Effect.provide(createMockConfig()),
+			);
+		});
+
+		it.effect("returns zero count for empty annotations", () =>
+			Effect.gen(function* () {
+				const syncer = yield* AnnotationSyncer;
+				const result = yield* syncer.syncToFile;
+
+				expect(result.count).toBe(0);
+			}).pipe(
+				Effect.provide(AnnotationSyncer.Default),
+				Effect.provide(createMockKavitaClient([])),
+				Effect.provide(createMockObsidianAdapter().layer),
+				Effect.provide(createMockConfig()),
+			),
+		);
+
+		it.effect("uses custom output path from config", () =>
+			Effect.gen(function* () {
+				const syncer = yield* AnnotationSyncer;
+				const result = yield* syncer.syncToFile;
+
+				expect(result.outputPath).toBe("custom/path.md");
+			}).pipe(
+				Effect.provide(AnnotationSyncer.Default),
+				Effect.provide(createMockKavitaClient([createAnnotation()])),
+				Effect.provide(createMockObsidianAdapter().layer),
+				Effect.provide(createMockConfig({ outputPath: "custom/path.md" })),
+			),
+		);
+
+		it.effect("respects includeSpoilers option", () => {
+			const mockObsidian = createMockObsidianAdapter();
+
+			return Effect.gen(function* () {
+				const syncer = yield* AnnotationSyncer;
+				yield* syncer.syncToFile;
+
+				const fileContent = mockObsidian.files.get("kavita-annotations.md");
+				expect(fileContent).toContain("Normal");
+				expect(fileContent).not.toContain("Spoiler");
+			}).pipe(
+				Effect.provide(AnnotationSyncer.Default),
+				Effect.provide(
+					createMockKavitaClient([
+						createAnnotation({ id: 1, content: "Normal", spoiler: false }),
+						createAnnotation({ id: 2, content: "Spoiler", spoiler: true }),
+					]),
+				),
+				Effect.provide(mockObsidian.layer),
+				Effect.provide(createMockConfig({ includeSpoilers: false })),
+			);
+		});
+	});
+});

--- a/src/services/AnnotationSyncer.ts
+++ b/src/services/AnnotationSyncer.ts
@@ -1,0 +1,67 @@
+/**
+ * Annotation syncer service for syncing Kavita annotations to Obsidian.
+ *
+ * @module
+ */
+import { Effect } from "effect";
+import type { KavitaNetworkError, ObsidianWriteError } from "../errors.js";
+import { toMarkdown } from "../formatters/markdown.js";
+import { KavitaClient } from "./KavitaClient.js";
+import { ObsidianAdapter } from "./ObsidianAdapter.js";
+import { PluginConfig } from "./PluginConfig.js";
+
+/**
+ * Result of a sync operation.
+ *
+ * @since 0.0.1
+ * @category Syncer
+ */
+export interface SyncResult {
+	readonly count: number;
+	readonly outputPath: string;
+}
+
+/**
+ * Annotation syncer service.
+ *
+ * Orchestrates fetching annotations from Kavita and writing them to Obsidian.
+ *
+ * @since 0.0.1
+ * @category Services
+ */
+export class AnnotationSyncer extends Effect.Service<AnnotationSyncer>()(
+	"AnnotationSyncer",
+	{
+		effect: Effect.gen(function* () {
+			const kavita = yield* KavitaClient;
+			const obsidian = yield* ObsidianAdapter;
+			const config = yield* PluginConfig;
+
+			/**
+			 * Sync all annotations to a single file.
+			 *
+			 * @since 0.0.1
+			 */
+			const syncToFile: Effect.Effect<
+				SyncResult,
+				KavitaNetworkError | ObsidianWriteError
+			> = Effect.gen(function* () {
+				const annotations = yield* kavita.fetchAllAnnotations;
+
+				const markdown = toMarkdown(annotations, {
+					includeComments: config.includeComments,
+					includeSpoilers: config.includeSpoilers,
+				});
+
+				yield* obsidian.writeFile(config.outputPath, markdown);
+
+				return {
+					count: annotations.length,
+					outputPath: config.outputPath,
+				};
+			});
+
+			return { syncToFile };
+		}),
+	},
+) {}


### PR DESCRIPTION
## Summary

- Adds pure markdown formatting module (`src/formatters/markdown.ts`) with `toMarkdown`, `formatAnnotation`, `groupBySeriesId`, `groupByChapterId` functions
- Adds `AnnotationSyncer` service (`src/services/AnnotationSyncer.ts`) with `syncToFile` for v0.0.1
- Supports grouping annotations by series and chapter
- Handles spoiler filtering and comment inclusion based on config

## Test plan

- [x] All 34 tests passing (12 formatter + 4 syncer + existing)
- [x] TypeScript compiles without errors
- [x] Biome lint passes

## Notes

Test refactoring to use Effect's `layer()` pattern and property-based testing with `Schema.Arbitrary` is planned for a follow-up.