### PR TITLE
feat: enriched markdown output with real names, wikilinks, and tags

### DIFF
--- a/src/formatters/markdown.test.ts
+++ b/src/formatters/markdown.test.ts
@@ -7,11 +7,28 @@ import { Option } from "effect";
 import { describe, expect, it } from "vitest";
 import type { AnnotationDto } from "../schemas.js";
 import {
+	type FormatOptions,
 	formatAnnotation,
+	generateFrontmatter,
+	generateSeriesHeader,
+	getChapterTitle,
+	getLibraryName,
+	getSeriesName,
 	groupByChapterId,
 	groupBySeriesId,
+	makeTag,
+	makeWikilink,
 	toMarkdown,
+	toSlug,
 } from "./markdown.js";
+
+const defaultOptions: FormatOptions = {
+	includeComments: true,
+	includeSpoilers: false,
+	includeTags: true,
+	tagPrefix: "kavita/",
+	includeWikilinks: true,
+};
 
 const createAnnotation = (
 	overrides: Partial<typeof AnnotationDto.Type> = {},
@@ -44,16 +61,153 @@ const createAnnotation = (
 	...overrides,
 });
 
+describe("toSlug", () => {
+	it("converts to lowercase", () => {
+		expect(toSlug("Hello World")).toBe("hello-world");
+	});
+
+	it("replaces spaces with hyphens", () => {
+		expect(toSlug("the great gatsby")).toBe("the-great-gatsby");
+	});
+
+	it("removes special characters", () => {
+		expect(toSlug("F. Scott Fitzgerald")).toBe("f-scott-fitzgerald");
+	});
+
+	it("collapses multiple hyphens", () => {
+		expect(toSlug("Fiction & Literature")).toBe("fiction-literature");
+	});
+
+	it("trims leading and trailing hyphens", () => {
+		expect(toSlug("  Hello  ")).toBe("hello");
+	});
+});
+
+describe("makeTag", () => {
+	it("creates prefixed tag with slug", () => {
+		expect(makeTag("kavita/", "series", "The Great Gatsby")).toBe(
+			"#kavita/series/the-great-gatsby",
+		);
+	});
+
+	it("works with different prefixes", () => {
+		expect(makeTag("book/", "author", "F. Scott Fitzgerald")).toBe(
+			"#book/author/f-scott-fitzgerald",
+		);
+	});
+});
+
+describe("makeWikilink", () => {
+	it("creates wikilink", () => {
+		expect(makeWikilink("The Great Gatsby")).toBe("[[The Great Gatsby]]");
+	});
+});
+
+describe("getSeriesName", () => {
+	it("returns seriesName when present", () => {
+		const annotation = createAnnotation({ seriesName: "The Great Gatsby" });
+		expect(getSeriesName(annotation)).toBe("The Great Gatsby");
+	});
+
+	it("falls back to seriesId when seriesName is null", () => {
+		const annotation = createAnnotation({ seriesName: null, seriesId: 123 });
+		expect(getSeriesName(annotation)).toBe("Series 123");
+	});
+});
+
+describe("getChapterTitle", () => {
+	it("returns chapterTitle when present", () => {
+		const annotation = createAnnotation({
+			chapterTitle: "Chapter 1: The Beginning",
+		});
+		expect(getChapterTitle(annotation)).toBe("Chapter 1: The Beginning");
+	});
+
+	it("falls back to chapterId when chapterTitle is null", () => {
+		const annotation = createAnnotation({ chapterTitle: null, chapterId: 42 });
+		expect(getChapterTitle(annotation)).toBe("Chapter 42");
+	});
+});
+
+describe("getLibraryName", () => {
+	it("returns libraryName when present", () => {
+		const annotation = createAnnotation({ libraryName: "Fiction" });
+		expect(getLibraryName(annotation)).toBe("Fiction");
+	});
+
+	it("falls back to libraryId when libraryName is null", () => {
+		const annotation = createAnnotation({ libraryName: null, libraryId: 5 });
+		expect(getLibraryName(annotation)).toBe("Library 5");
+	});
+});
+
+describe("generateFrontmatter", () => {
+	it("generates frontmatter with tags", () => {
+		const result = generateFrontmatter(defaultOptions);
+		expect(result).toContain("---");
+		expect(result).toContain("title: Kavita Annotations");
+		expect(result).toContain("tags:");
+		expect(result).toContain("  - kavita");
+		expect(result).toContain("  - annotations");
+		expect(result).toContain("updated:");
+	});
+
+	it("omits tags when includeTags is false", () => {
+		const result = generateFrontmatter({
+			...defaultOptions,
+			includeTags: false,
+		});
+		expect(result).not.toContain("tags:");
+		expect(result).toContain("title: Kavita Annotations");
+	});
+});
+
+describe("generateSeriesHeader", () => {
+	it("generates header with wikilinks and tags", () => {
+		const annotation = createAnnotation({
+			seriesName: "The Great Gatsby",
+			libraryName: "Fiction",
+		});
+		const lines = generateSeriesHeader(annotation, defaultOptions);
+
+		expect(lines).toContain("## The Great Gatsby");
+		expect(lines).toContain("**Series:** [[The Great Gatsby]]");
+		expect(lines).toContain("**Library:** Fiction");
+		expect(
+			lines.some((l) => l.includes("#kavita/series/the-great-gatsby")),
+		).toBe(true);
+		expect(lines.some((l) => l.includes("#kavita/library/fiction"))).toBe(true);
+	});
+
+	it("omits wikilinks when disabled", () => {
+		const annotation = createAnnotation({ seriesName: "Test Series" });
+		const lines = generateSeriesHeader(annotation, {
+			...defaultOptions,
+			includeWikilinks: false,
+		});
+
+		expect(lines).not.toContain("**Series:** [[Test Series]]");
+		expect(lines).toContain("## Test Series");
+	});
+
+	it("omits tags when disabled", () => {
+		const annotation = createAnnotation({ seriesName: "Test Series" });
+		const lines = generateSeriesHeader(annotation, {
+			...defaultOptions,
+			includeTags: false,
+		});
+
+		expect(lines.some((l) => l.includes("**Tags:**"))).toBe(false);
+	});
+});
+
 describe("formatAnnotation", () => {
 	it("formats basic annotation", () => {
 		const annotation = createAnnotation({
 			selectedText: "Hello world",
 			pageNumber: 0,
 		});
-		const result = formatAnnotation(annotation, {
-			includeComments: true,
-			includeSpoilers: false,
-		});
+		const result = formatAnnotation(annotation, defaultOptions);
 
 		expect(Option.isSome(result)).toBe(true);
 		if (Option.isSome(result)) {
@@ -66,10 +220,7 @@ describe("formatAnnotation", () => {
 			selectedText: "Highlight",
 			comment: "My note",
 		});
-		const result = formatAnnotation(annotation, {
-			includeComments: true,
-			includeSpoilers: false,
-		});
+		const result = formatAnnotation(annotation, defaultOptions);
 
 		expect(Option.isSome(result)).toBe(true);
 		if (Option.isSome(result)) {
@@ -83,8 +234,8 @@ describe("formatAnnotation", () => {
 			comment: "My note",
 		});
 		const result = formatAnnotation(annotation, {
+			...defaultOptions,
 			includeComments: false,
-			includeSpoilers: false,
 		});
 
 		expect(Option.isSome(result)).toBe(true);
@@ -98,10 +249,7 @@ describe("formatAnnotation", () => {
 			selectedText: "Highlight",
 			pageNumber: 42,
 		});
-		const result = formatAnnotation(annotation, {
-			includeComments: true,
-			includeSpoilers: false,
-		});
+		const result = formatAnnotation(annotation, defaultOptions);
 
 		expect(Option.isSome(result)).toBe(true);
 		if (Option.isSome(result)) {
@@ -114,10 +262,7 @@ describe("formatAnnotation", () => {
 			selectedText: "Spoiler",
 			containsSpoiler: true,
 		});
-		const result = formatAnnotation(annotation, {
-			includeComments: true,
-			includeSpoilers: false,
-		});
+		const result = formatAnnotation(annotation, defaultOptions);
 
 		expect(Option.isNone(result)).toBe(true);
 	});
@@ -128,7 +273,7 @@ describe("formatAnnotation", () => {
 			containsSpoiler: true,
 		});
 		const result = formatAnnotation(annotation, {
-			includeComments: true,
+			...defaultOptions,
 			includeSpoilers: true,
 		});
 
@@ -170,47 +315,93 @@ describe("groupByChapterId", () => {
 
 describe("toMarkdown", () => {
 	it("returns empty message for no annotations", () => {
-		const result = toMarkdown([], {
-			includeComments: true,
-			includeSpoilers: false,
-		});
+		const result = toMarkdown([], defaultOptions);
 
+		expect(result).toContain("---");
+		expect(result).toContain("title: Kavita Annotations");
 		expect(result).toContain("# Kavita Annotations");
 		expect(result).toContain("*No annotations found.*");
 	});
 
-	it("generates markdown with series and chapter grouping", () => {
+	it("generates markdown with series name and chapter title", () => {
 		const annotations = [
 			createAnnotation({
 				id: 1,
 				seriesId: 1,
+				seriesName: "The Great Gatsby",
 				chapterId: 1,
+				chapterTitle: "Chapter 1: In My Younger Years",
+				libraryName: "Fiction",
+				selectedText: "First highlight",
+			}),
+		];
+
+		const result = toMarkdown(annotations, defaultOptions);
+
+		expect(result).toContain("## The Great Gatsby");
+		expect(result).toContain("### Chapter 1: In My Younger Years");
+		expect(result).toContain("**Series:** [[The Great Gatsby]]");
+		expect(result).toContain("**Library:** Fiction");
+		expect(result).toContain("#kavita/series/the-great-gatsby");
+		expect(result).toContain("> First highlight");
+	});
+
+	it("falls back to IDs when names are missing", () => {
+		const annotations = [
+			createAnnotation({
+				id: 1,
+				seriesId: 123,
+				seriesName: null,
+				chapterId: 456,
+				chapterTitle: null,
+				libraryName: null,
+				libraryId: 7,
+				selectedText: "Highlight",
+			}),
+		];
+
+		const result = toMarkdown(annotations, defaultOptions);
+
+		expect(result).toContain("## Series 123");
+		expect(result).toContain("### Chapter 456");
+		expect(result).toContain("**Library:** Library 7");
+	});
+
+	it("generates markdown with multiple series and chapters", () => {
+		const annotations = [
+			createAnnotation({
+				id: 1,
+				seriesId: 1,
+				seriesName: "Book One",
+				chapterId: 1,
+				chapterTitle: "Chapter 1",
 				selectedText: "First",
 			}),
 			createAnnotation({
 				id: 2,
 				seriesId: 1,
+				seriesName: "Book One",
 				chapterId: 2,
+				chapterTitle: "Chapter 2",
 				selectedText: "Second",
 			}),
 			createAnnotation({
 				id: 3,
 				seriesId: 2,
+				seriesName: "Book Two",
 				chapterId: 1,
+				chapterTitle: "Introduction",
 				selectedText: "Third",
 			}),
 		];
 
-		const result = toMarkdown(annotations, {
-			includeComments: true,
-			includeSpoilers: false,
-		});
+		const result = toMarkdown(annotations, defaultOptions);
 
-		expect(result).toContain("# Kavita Annotations");
-		expect(result).toContain("## Series 1");
-		expect(result).toContain("## Series 2");
+		expect(result).toContain("## Book One");
+		expect(result).toContain("## Book Two");
 		expect(result).toContain("### Chapter 1");
 		expect(result).toContain("### Chapter 2");
+		expect(result).toContain("### Introduction");
 		expect(result).toContain("> First");
 		expect(result).toContain("> Second");
 		expect(result).toContain("> Third");
@@ -230,12 +421,45 @@ describe("toMarkdown", () => {
 			}),
 		];
 
-		const result = toMarkdown(annotations, {
-			includeComments: true,
-			includeSpoilers: false,
-		});
+		const result = toMarkdown(annotations, defaultOptions);
 
 		expect(result).toContain("> Normal");
 		expect(result).not.toContain("> Secret");
+	});
+
+	it("respects includeTags option", () => {
+		const annotations = [
+			createAnnotation({
+				seriesName: "Test Book",
+				selectedText: "Highlight",
+			}),
+		];
+
+		const resultWithTags = toMarkdown(annotations, defaultOptions);
+		const resultWithoutTags = toMarkdown(annotations, {
+			...defaultOptions,
+			includeTags: false,
+		});
+
+		expect(resultWithTags).toContain("#kavita/series/test-book");
+		expect(resultWithoutTags).not.toContain("#kavita/series/test-book");
+	});
+
+	it("respects includeWikilinks option", () => {
+		const annotations = [
+			createAnnotation({
+				seriesName: "Test Book",
+				selectedText: "Highlight",
+			}),
+		];
+
+		const resultWithLinks = toMarkdown(annotations, defaultOptions);
+		const resultWithoutLinks = toMarkdown(annotations, {
+			...defaultOptions,
+			includeWikilinks: false,
+		});
+
+		expect(resultWithLinks).toContain("[[Test Book]]");
+		expect(resultWithoutLinks).not.toContain("[[Test Book]]");
 	});
 });

--- a/src/formatters/markdown.ts
+++ b/src/formatters/markdown.ts
@@ -15,7 +15,47 @@ import type { AnnotationDto } from "../schemas.js";
 export interface FormatOptions {
 	readonly includeComments: boolean;
 	readonly includeSpoilers: boolean;
+	/** @since 0.0.2 */
+	readonly includeTags: boolean;
+	/** @since 0.0.2 */
+	readonly tagPrefix: string;
+	/** @since 0.0.2 */
+	readonly includeWikilinks: boolean;
 }
+
+/**
+ * Convert a string to a URL-safe slug for tags.
+ *
+ * @since 0.0.2
+ * @category Formatters
+ */
+export const toSlug = (input: string): string =>
+	input
+		.toLowerCase()
+		.replace(/[^a-z0-9\s-]/g, "")
+		.replace(/\s+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
+
+/**
+ * Generate a prefixed tag.
+ *
+ * @since 0.0.2
+ * @category Formatters
+ */
+export const makeTag = (
+	prefix: string,
+	category: string,
+	value: string,
+): string => `#${prefix}${category}/${toSlug(value)}`;
+
+/**
+ * Generate a wikilink.
+ *
+ * @since 0.0.2
+ * @category Formatters
+ */
+export const makeWikilink = (value: string): string => `[[${value}]]`;
 
 /**
  * Format a single annotation to markdown.
@@ -50,6 +90,34 @@ export const formatAnnotation = (
 };
 
 /**
+ * Get the series name from an annotation, falling back to ID.
+ *
+ * @since 0.0.2
+ * @category Formatters
+ */
+export const getSeriesName = (annotation: typeof AnnotationDto.Type): string =>
+	annotation.seriesName ?? `Series ${annotation.seriesId}`;
+
+/**
+ * Get the chapter title from an annotation, falling back to ID.
+ *
+ * @since 0.0.2
+ * @category Formatters
+ */
+export const getChapterTitle = (
+	annotation: typeof AnnotationDto.Type,
+): string => annotation.chapterTitle ?? `Chapter ${annotation.chapterId}`;
+
+/**
+ * Get the library name from an annotation, falling back to ID.
+ *
+ * @since 0.0.2
+ * @category Formatters
+ */
+export const getLibraryName = (annotation: typeof AnnotationDto.Type): string =>
+	annotation.libraryName ?? `Library ${annotation.libraryId}`;
+
+/**
  * Group annotations by seriesId.
  *
  * @since 0.0.1
@@ -72,6 +140,59 @@ export const groupByChapterId = (
 	Array.groupBy(annotations, (a) => String(a.chapterId));
 
 /**
+ * Generate YAML frontmatter for the annotations document.
+ *
+ * @since 0.0.2
+ * @category Formatters
+ */
+export const generateFrontmatter = (options: FormatOptions): string => {
+	const lines = ["---", "title: Kavita Annotations"];
+
+	if (options.includeTags) {
+		lines.push("tags:");
+		lines.push(`  - ${options.tagPrefix.replace(/\/$/, "")}`);
+		lines.push("  - annotations");
+	}
+
+	lines.push(`updated: ${new Date().toISOString()}`);
+	lines.push("---");
+
+	return lines.join("\n");
+};
+
+/**
+ * Generate series header with metadata.
+ *
+ * @since 0.0.2
+ * @category Formatters
+ */
+export const generateSeriesHeader = (
+	firstAnnotation: typeof AnnotationDto.Type,
+	options: FormatOptions,
+): string[] => {
+	const seriesName = getSeriesName(firstAnnotation);
+	const libraryName = getLibraryName(firstAnnotation);
+
+	const lines: string[] = [`## ${seriesName}`];
+
+	if (options.includeWikilinks) {
+		lines.push(`**Series:** ${makeWikilink(seriesName)}`);
+	}
+
+	lines.push(`**Library:** ${libraryName}`);
+
+	if (options.includeTags) {
+		const tags: string[] = [
+			makeTag(options.tagPrefix, "series", seriesName),
+			makeTag(options.tagPrefix, "library", libraryName),
+		];
+		lines.push(`**Tags:** ${tags.join(" ")}`);
+	}
+
+	return lines;
+};
+
+/**
  * Convert annotations to a markdown document.
  *
  * @since 0.0.1
@@ -81,37 +202,47 @@ export const toMarkdown = (
 	annotations: ReadonlyArray<typeof AnnotationDto.Type>,
 	options: FormatOptions,
 ): string => {
+	const frontmatter = generateFrontmatter(options);
+
 	if (annotations.length === 0) {
-		return "# Kavita Annotations\n\n*No annotations found.*\n";
+		return `${frontmatter}\n\n# Kavita Annotations\n\n*No annotations found.*\n`;
 	}
 
 	const seriesGroups = groupBySeriesId(annotations);
 
 	const content = pipe(
 		Record.toEntries(seriesGroups),
-		Array.flatMap(([seriesId, seriesAnnotations]) => {
-			const seriesTitle =
-				seriesId !== "undefined" ? `Series ${seriesId}` : "Ungrouped";
+		Array.flatMap(([_seriesId, seriesAnnotations]) => {
+			const firstAnnotation = seriesAnnotations[0];
+			if (!firstAnnotation) return [];
+
 			const chapterGroups = groupByChapterId(seriesAnnotations);
 
 			return [
-				`## ${seriesTitle}`,
+				...generateSeriesHeader(firstAnnotation, options),
 				"",
 				...pipe(
 					Record.toEntries(chapterGroups),
-					Array.flatMap(([chapterId, chapterAnnotations]) => [
-						`### Chapter ${chapterId}`,
-						"",
-						...pipe(
-							chapterAnnotations,
-							Array.filterMap((a) => formatAnnotation(a, options)),
-							Array.flatMap((formatted) => [formatted, "", "---", ""]),
-						),
-					]),
+					Array.flatMap(([_chapterId, chapterAnnotations]) => {
+						const firstChapterAnnotation = chapterAnnotations[0];
+						const chapterTitle = firstChapterAnnotation
+							? getChapterTitle(firstChapterAnnotation)
+							: "Unknown Chapter";
+
+						return [
+							`### ${chapterTitle}`,
+							"",
+							...pipe(
+								chapterAnnotations,
+								Array.filterMap((a) => formatAnnotation(a, options)),
+								Array.flatMap((formatted) => [formatted, "", "---", ""]),
+							),
+						];
+					}),
 				),
 			];
 		}),
 	);
 
-	return ["# Kavita Annotations", "", ...content].join("\n");
+	return [frontmatter, "", "# Kavita Annotations", "", ...content].join("\n");
 };

--- a/src/services/AnnotationSyncer.test.ts
+++ b/src/services/AnnotationSyncer.test.ts
@@ -91,6 +91,9 @@ const createMockConfig = (
 		matchThreshold: 0.7,
 		includeComments: true,
 		includeSpoilers: false,
+		includeTags: true,
+		tagPrefix: "kavita/",
+		includeWikilinks: true,
 		...overrides,
 	} as unknown as typeof PluginConfig.Service);
 

--- a/src/services/AnnotationSyncer.ts
+++ b/src/services/AnnotationSyncer.ts
@@ -60,6 +60,9 @@ export class AnnotationSyncer extends Effect.Service<AnnotationSyncer>()(
 				const markdown = toMarkdown(annotations, {
 					includeComments: config.includeComments,
 					includeSpoilers: config.includeSpoilers,
+					includeTags: config.includeTags,
+					tagPrefix: config.tagPrefix,
+					includeWikilinks: config.includeWikilinks,
 				});
 
 				yield* obsidian.writeFile(config.outputPath, markdown);


### PR DESCRIPTION
## Summary

Transforms the markdown output from basic numeric IDs to rich, Obsidian-native formatting:

- **Real names**: Uses `seriesName`, `chapterTitle`, `libraryName` from AnnotationDto instead of numeric IDs
- **YAML frontmatter**: Adds title, tags, and updated timestamp for Dataview compatibility
- **Wikilinks**: Generates `[[Series Name]]` links for auto-linking to existing notes
- **Prefixed tags**: Creates `#kavita/series/...`, `#kavita/library/...` tags with URL-safe slugs
- **Fallback to IDs**: Gracefully falls back to numeric IDs when names are null

### New output format

```markdown
---
title: Kavita Annotations
tags:
  - kavita
  - annotations
updated: 2025-01-15T10:30:00Z
---

# Kavita Annotations

## The Great Gatsby
**Series:** [[The Great Gatsby]]
**Library:** Fiction
**Tags:** #kavita/series/the-great-gatsby #kavita/library/fiction

### Chapter 1: In My Younger Years

> In my younger and more vulnerable years...

*Note:* Great opening line

<small>Page 3</small>
```

## Test plan

- [x] TypeScript compiles without errors
- [x] All 56 unit tests pass (23 new tests added)
- [x] Build succeeds
- [x] Manual test: verify output format in Obsidian