### PR TITLE
fix: parse Quill Delta JSON in annotation comments

### DIFF
--- a/src/formatters/bookFile.test.ts
+++ b/src/formatters/bookFile.test.ts
@@ -181,6 +181,47 @@ describe("formatBookAnnotation", () => {
 		}
 	});
 
+	it("uses commentPlainText when available", () => {
+		const annotation = createAnnotation({
+			comment: '{"ops":[{"insert":"JSON note\n"}]}',
+			commentPlainText: "Plain text note",
+		});
+		const result = formatBookAnnotation(annotation, defaultFormatOptions);
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toContain("*Note:* Plain text note");
+			expect(result.value).not.toContain("JSON note");
+		}
+	});
+
+	it("extracts text from Quill Delta JSON when commentPlainText is not available", () => {
+		const annotation = createAnnotation({
+			comment: '{"ops":[{"insert":"Just testing annotations\\n"}]}',
+			commentPlainText: null,
+		});
+		const result = formatBookAnnotation(annotation, defaultFormatOptions);
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toContain("*Note:* Just testing annotations");
+			expect(result.value).not.toContain('{"ops"');
+		}
+	});
+
+	it("falls back to plain comment when Quill Delta parsing fails", () => {
+		const annotation = createAnnotation({
+			comment: "Plain text comment",
+			commentPlainText: null,
+		});
+		const result = formatBookAnnotation(annotation, defaultFormatOptions);
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toContain("*Note:* Plain text comment");
+		}
+	});
+
 	it("excludes comment when disabled", () => {
 		const annotation = createAnnotation();
 		const options = { ...defaultFormatOptions, includeComments: false };

--- a/src/formatters/bookFile.ts
+++ b/src/formatters/bookFile.ts
@@ -9,7 +9,7 @@
 import { Array, Option, pipe } from "effect";
 import type { AnnotationDto } from "../schemas.js";
 import type { FormatOptions } from "./markdown.js";
-import { toSlug } from "./markdown.js";
+import { getCommentText, toSlug } from "./markdown.js";
 
 /**
  * Options for formatting a book file.
@@ -133,14 +133,11 @@ export const formatBookAnnotation = (
 		.join("\n");
 	lines.push(blockquote);
 
-	const hasComment =
-		annotation.comment &&
-		annotation.comment.trim() !== "" &&
-		annotation.comment.trim() !== "{}";
+	const commentText = getCommentText(annotation);
 
-	if (options.includeComments && hasComment) {
+	if (options.includeComments && commentText) {
 		lines.push("");
-		lines.push(`*Note:* ${annotation.comment}`);
+		lines.push(`*Note:* ${commentText}`);
 	}
 
 	if (annotation.pageNumber !== undefined && annotation.pageNumber > 0) {

--- a/src/formatters/markdown.test.ts
+++ b/src/formatters/markdown.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import type { AnnotationDto, SeriesMetadataDto } from "../schemas.js";
 import {
 	type ChapterInfoMap,
+	extractTextFromQuillDelta,
 	type FormatOptions,
 	formatAnnotation,
 	generateBookHeader,
@@ -17,6 +18,7 @@ import {
 	getBookSortOrder,
 	getBookTitle,
 	getChapterTitle,
+	getCommentText,
 	getGenreNames,
 	getLibraryName,
 	getSeriesName,
@@ -105,6 +107,166 @@ describe("makeTag", () => {
 describe("makeWikilink", () => {
 	it("creates wikilink", () => {
 		expect(makeWikilink("The Great Gatsby")).toBe("[[The Great Gatsby]]");
+	});
+});
+
+describe("extractTextFromQuillDelta", () => {
+	it("extracts text from valid Quill Delta", () => {
+		expect(extractTextFromQuillDelta('{"ops":[{"insert":"Hello\\n"}]}')).toBe(
+			"Hello",
+		);
+	});
+
+	it("handles multiple insert operations", () => {
+		expect(
+			extractTextFromQuillDelta('{"ops":[{"insert":"Hello "},{"insert":"World\\n"}]}'),
+		).toBe("Hello World");
+	});
+
+	it("returns null for non-JSON string", () => {
+		expect(extractTextFromQuillDelta("plain text")).toBe(null);
+	});
+
+	it("returns null for empty ops array", () => {
+		expect(extractTextFromQuillDelta('{"ops":[]}')).toBe(null);
+	});
+
+	it("returns null for ops with only retain operations", () => {
+		expect(extractTextFromQuillDelta('{"ops":[{"retain":5}]}')).toBe(null);
+	});
+
+	it("returns null for ops with only delete operations", () => {
+		expect(extractTextFromQuillDelta('{"ops":[{"delete":3}]}')).toBe(null);
+	});
+
+	it("ignores non-string insert values (embeds)", () => {
+		expect(
+			extractTextFromQuillDelta('{"ops":[{"insert":{"image":"url"}}]}'),
+		).toBe(null);
+	});
+
+	it("handles mixed operations (extracts only insert strings)", () => {
+		expect(
+			extractTextFromQuillDelta(
+				'{"ops":[{"retain":5},{"insert":"text"},{"delete":2}]}',
+			),
+		).toBe("text");
+	});
+
+	it("returns null for malformed JSON", () => {
+		expect(extractTextFromQuillDelta('{"ops":invalid}')).toBe(null);
+	});
+
+	it("returns null for JSON without ops", () => {
+		expect(extractTextFromQuillDelta('{"foo":"bar"}')).toBe(null);
+	});
+
+	it("returns null for ops that is not an array", () => {
+		expect(extractTextFromQuillDelta('{"ops":"not an array"}')).toBe(null);
+	});
+
+	it("returns null for empty string", () => {
+		expect(extractTextFromQuillDelta("")).toBe(null);
+	});
+
+	it("returns null for empty object", () => {
+		expect(extractTextFromQuillDelta("{}")).toBe(null);
+	});
+
+	it("handles whitespace in JSON", () => {
+		expect(extractTextFromQuillDelta('  {"ops":[{"insert":"test\\n"}]}  ')).toBe(
+			"test",
+		);
+	});
+
+	it("handles insert with attributes (ignores attributes, keeps text)", () => {
+		expect(
+			extractTextFromQuillDelta(
+				'{"ops":[{"insert":"bold text","attributes":{"bold":true}}]}',
+			),
+		).toBe("bold text");
+	});
+});
+
+describe("getCommentText", () => {
+	it("returns commentPlainText when available", () => {
+		const annotation = createAnnotation({
+			commentPlainText: "Plain text note",
+			comment: '{"ops":[{"insert":"JSON note\\n"}]}',
+		});
+		expect(getCommentText(annotation)).toBe("Plain text note");
+	});
+
+	it("extracts from Quill Delta when commentPlainText is null", () => {
+		const annotation = createAnnotation({
+			commentPlainText: null,
+			comment: '{"ops":[{"insert":"Quill note\\n"}]}',
+		});
+		expect(getCommentText(annotation)).toBe("Quill note");
+	});
+
+	it("returns plain text when comment is not JSON-like", () => {
+		const annotation = createAnnotation({
+			commentPlainText: null,
+			comment: "Plain text comment",
+		});
+		expect(getCommentText(annotation)).toBe("Plain text comment");
+	});
+
+	it("returns null for malformed JSON (does not expose raw JSON)", () => {
+		const annotation = createAnnotation({
+			commentPlainText: null,
+			comment: '{"ops":invalid}',
+		});
+		expect(getCommentText(annotation)).toBe(null);
+	});
+
+	it("returns null for empty comment", () => {
+		const annotation = createAnnotation({
+			commentPlainText: null,
+			comment: "",
+		});
+		expect(getCommentText(annotation)).toBe(null);
+	});
+
+	it("returns null for empty object comment", () => {
+		const annotation = createAnnotation({
+			commentPlainText: null,
+			comment: "{}",
+		});
+		expect(getCommentText(annotation)).toBe(null);
+	});
+
+	it("returns null when both fields are null", () => {
+		const annotation = createAnnotation({
+			commentPlainText: null,
+			comment: null,
+		});
+		expect(getCommentText(annotation)).toBe(null);
+	});
+
+	it("trims whitespace from commentPlainText", () => {
+		const annotation = createAnnotation({
+			commentPlainText: "  trimmed  ",
+			comment: null,
+		});
+		expect(getCommentText(annotation)).toBe("trimmed");
+	});
+
+	it("trims whitespace from plain text comment", () => {
+		const annotation = createAnnotation({
+			commentPlainText: null,
+			comment: "  trimmed  ",
+		});
+		expect(getCommentText(annotation)).toBe("trimmed");
+	});
+
+	it("returns null for whitespace-only commentPlainText with JSON comment", () => {
+		const annotation = createAnnotation({
+			commentPlainText: "   ",
+			comment: '{"ops":[{"insert":"fallback\\n"}]}',
+		});
+		expect(getCommentText(annotation)).toBe("fallback");
 	});
 });
 
@@ -324,6 +486,50 @@ describe("formatAnnotation", () => {
 		expect(Option.isSome(result)).toBe(true);
 		if (Option.isSome(result)) {
 			expect(result.value).toContain("*Note:* My note");
+		}
+	});
+
+	it("uses commentPlainText when available", () => {
+		const annotation = createAnnotation({
+			selectedText: "Highlight",
+			comment: '{"ops":[{"insert":"JSON note\n"}]}',
+			commentPlainText: "Plain text note",
+		});
+		const result = formatAnnotation(annotation, defaultOptions);
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toContain("*Note:* Plain text note");
+			expect(result.value).not.toContain("JSON note");
+		}
+	});
+
+	it("extracts text from Quill Delta JSON when commentPlainText is not available", () => {
+		const annotation = createAnnotation({
+			selectedText: "Highlight",
+			comment: '{"ops":[{"insert":"Just testing annotations\\n"}]}',
+			commentPlainText: null,
+		});
+		const result = formatAnnotation(annotation, defaultOptions);
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toContain("*Note:* Just testing annotations");
+			expect(result.value).not.toContain('{"ops"');
+		}
+	});
+
+	it("falls back to plain comment when Quill Delta parsing fails", () => {
+		const annotation = createAnnotation({
+			selectedText: "Highlight",
+			comment: "Plain text comment",
+			commentPlainText: null,
+		});
+		const result = formatAnnotation(annotation, defaultOptions);
+
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value).toContain("*Note:* Plain text comment");
 		}
 	});
 

--- a/src/formatters/markdown.ts
+++ b/src/formatters/markdown.ts
@@ -95,6 +95,137 @@ export const makeTag = (value: string, prefix = ""): string =>
 export const makeWikilink = (value: string): string => `[[${value}]]`;
 
 /**
+ * Extract plain text from Quill Delta JSON format.
+ *
+ * Quill Delta is a rich text format used by the Quill editor.
+ * This function extracts only the plain text from insert operations.
+ *
+ * Limitations:
+ * - Only extracts text from 'insert' operations
+ * - Ignores formatting attributes (bold, italic, links, etc.)
+ * - Ignores retain/delete operations
+ * - Ignores embedded objects (images, etc.)
+ *
+ * @example
+ * ```ts
+ * extractTextFromQuillDelta('{"ops":[{"insert":"Hello\\n"}]}') // "Hello"
+ * extractTextFromQuillDelta('{"ops":[{"retain":5}]}') // null
+ * extractTextFromQuillDelta('plain text') // null
+ * ```
+ *
+ * @since 1.1.2
+ * @category Formatters
+ */
+export const extractTextFromQuillDelta = (deltaJson: string): string | null => {
+	const trimmed = deltaJson.trim();
+
+	// Early exit for non-JSON strings (performance optimization)
+	if (!trimmed.startsWith("{")) {
+		return null;
+	}
+
+	try {
+		const delta = JSON.parse(trimmed) as unknown;
+
+		// Validate structure
+		if (
+			!delta ||
+			typeof delta !== "object" ||
+			!("ops" in delta) ||
+			!Array.isArray((delta as { ops: unknown }).ops)
+		) {
+			return null;
+		}
+
+		const ops = (delta as { ops: unknown[] }).ops;
+		if (ops.length === 0) {
+			return null;
+		}
+
+		const textParts: string[] = [];
+
+		for (const op of ops) {
+			if (op && typeof op === "object" && "insert" in op) {
+				const insert = (op as { insert: unknown }).insert;
+				// Only handle string inserts, ignore embeds (objects) and other types
+				if (typeof insert === "string") {
+					textParts.push(insert);
+				}
+			}
+			// Ignore retain/delete operations - they don't contain text
+		}
+
+		const text = textParts.join("").trim();
+		return text || null;
+	} catch {
+		// Invalid JSON - not a Quill Delta
+		return null;
+	}
+};
+
+/**
+ * Get the comment text from an annotation, preferring plain text over Quill Delta.
+ *
+ * Priority:
+ * 1. `commentPlainText` (if available and non-empty)
+ * 2. Parsed Quill Delta JSON from `comment` (if valid JSON starting with `{`)
+ * 3. Plain text `comment` (if not JSON-like)
+ * 4. `null` (for invalid/empty comments or unparseable JSON)
+ *
+ * @example
+ * ```ts
+ * // With commentPlainText
+ * getCommentText({ commentPlainText: "My note", comment: '{"ops":[...]}' }) // "My note"
+ *
+ * // With Quill Delta
+ * getCommentText({ commentPlainText: null, comment: '{"ops":[{"insert":"My note\\n"}]}' }) // "My note"
+ *
+ * // With plain text comment
+ * getCommentText({ commentPlainText: null, comment: 'Plain text' }) // "Plain text"
+ *
+ * // With malformed JSON (returns null to avoid exposing raw JSON)
+ * getCommentText({ commentPlainText: null, comment: '{"ops":invalid}' }) // null
+ * ```
+ *
+ * @since 1.1.2
+ * @category Formatters
+ */
+export const getCommentText = (
+	annotation: typeof AnnotationDto.Type,
+): string | null => {
+	// Priority 1: Use commentPlainText if available
+	if (annotation.commentPlainText) {
+		const trimmed = annotation.commentPlainText.trim();
+		if (trimmed) {
+			return trimmed;
+		}
+	}
+
+	// Priority 2/3: Handle comment field
+	if (annotation.comment) {
+		const trimmed = annotation.comment.trim();
+		if (!trimmed || trimmed === "{}") {
+			return null;
+		}
+
+		// If it looks like JSON, try to parse as Quill Delta
+		if (trimmed.startsWith("{")) {
+			const extracted = extractTextFromQuillDelta(trimmed);
+			if (extracted) {
+				return extracted;
+			}
+			// Failed to parse as Quill Delta - return null to avoid exposing raw JSON
+			return null;
+		}
+
+		// Not JSON-like, treat as plain text
+		return trimmed;
+	}
+
+	return null;
+};
+
+/**
  * Format a single annotation to markdown.
  *
  * @since 0.0.3
@@ -117,14 +248,11 @@ export const formatAnnotation = (
 		.join("\n");
 	lines.push(blockquote);
 
-	const hasComment =
-		annotation.comment &&
-		annotation.comment.trim() !== "" &&
-		annotation.comment.trim() !== "{}";
+	const commentText = getCommentText(annotation);
 
-	if (options.includeComments && hasComment) {
+	if (options.includeComments && commentText) {
 		lines.push("");
-		lines.push(`*Note:* ${annotation.comment}`);
+		lines.push(`*Note:* ${commentText}`);
 	}
 
 	if (annotation.pageNumber !== undefined && annotation.pageNumber > 0) {


### PR DESCRIPTION
This PR is AI generated. I've verified tests working and did manual testing. See screenshot
<img width="530" height="625" alt="image" src="https://github.com/user-attachments/assets/fa486200-db62-4724-98c6-b8efff7118de" />

Fixes https://github.com/davidlbowman/kavita-to-obsidian/issues/27

Fix bug where annotation comments were exported as raw JSON instead of formatted text. Refactor to remove code duplication and add comprehensive edge case tests.

- Extract shared utilities to markdown.ts
- Add early JSON detection for performance
- Fix fallback to never expose raw JSON
- Add 25 new edge case tests

Fixes: JSON structure displayed in exported annotations