### PR TITLE
fix: switch bundler from Bun to esbuild to fix plugin loading

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "kavita-sync",
 	"name": "Kavita Sync",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"minAppVersion": "0.15.0",
 	"description": "Sync annotations and highlights from your Kavita server to your vault.",
 	"author": "David Bowman",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kavita-to-obsidian",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"module": "src/index.ts",
 	"type": "module",
 	"private": true,

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,18 +1,20 @@
 /**
- * Build script for Obsidian plugin using Bun's bundler.
+ * Build script for Obsidian plugin using esbuild.
  *
  * Usage:
  *   bun run scripts/build.ts              # Development build
  *   bun run scripts/build.ts --production # Production build (minified)
  */
 
+import esbuild from "esbuild";
+
 const isProduction = process.argv.includes("--production");
 
-const result = await Bun.build({
-	entrypoints: ["src/main.ts"],
-	outdir: ".",
-	naming: "main.js",
-	target: "node",
+await esbuild.build({
+	entryPoints: ["src/main.ts"],
+	bundle: true,
+	outfile: "main.js",
+	platform: "node",
 	format: "cjs",
 	external: [
 		"obsidian",
@@ -30,17 +32,7 @@ const result = await Bun.build({
 		"@lezer/lr",
 	],
 	minify: isProduction,
-	sourcemap: isProduction ? "none" : "inline",
+	sourcemap: isProduction ? false : "inline",
+	treeShaking: true,
+	logLevel: "info",
 });
-
-if (!result.success) {
-	console.error("Build failed:");
-	for (const log of result.logs) {
-		console.error(log);
-	}
-	process.exit(1);
-}
-
-console.log(
-	`Build complete: main.js (${isProduction ? "production" : "development"})`,
-);


### PR DESCRIPTION
## Summary
- Bun's bundler produces CJS output with getter-based exports that resolve to `undefined` when loaded by Obsidian's Electron `require()`, causing "failed to load plugin" errors
- Switched `scripts/build.ts` from `Bun.build()` to `esbuild.build()` (esbuild was already installed as a transitive dependency)
- Bumped version to 1.2.1

## Test plan
- [x] `bun run build` produces correct CJS output with valid `module.exports.default`
- [x] `bun run typecheck` passes
- [x] `bun run test` — 244 tests pass
- [x] `bun run lint` and `bun run lint:obsidian` pass
- [x] Install built plugin in Obsidian vault and verify it loads without "failed to load plugin" error

Closes #41